### PR TITLE
fix: add double quotes

### DIFF
--- a/configs/uni-konstanz.config
+++ b/configs/uni-konstanz.config
@@ -1,6 +1,6 @@
 # Config for Uni Konstanz
-ILIAS_URL=https://ilias.uni-konstanz.de/
-ILIAS_PREFIX=ILIASKONSTANZ
-ILIAS_LOGIN_GET=login.php?client_id=ILIASKONSTANZ&cmd=force_login&lang=de
-ILIAS_HOME=ilias.php?baseClass=ilDashboardGUI&cmd=jumpToSelectedItems
-ILIAS_LOGOUT=logout.php?lang=de
+ILIAS_URL="https://ilias.uni-konstanz.de/"
+ILIAS_PREFIX="ILIASKONSTANZ"
+ILIAS_LOGIN_GET="login.php?client_id=ILIASKONSTANZ&cmd=force_login&lang=de"
+ILIAS_HOME="ilias.php?baseClass=ilDashboardGUI&cmd=jumpToSelectedItems"
+ILIAS_LOGOUT="logout.php?lang=de"


### PR DESCRIPTION
Otherwise it may have issue handing symbols in Login URL.

[Config] ILIAS_URL=https://ilias.uni-konstanz.de/
[Config] ILIAS_PREFIX=ILIASKONSTANZ
[Config] Ilias Login Pfad nicht gesetzt.